### PR TITLE
feat: set a user agent when downloading CLI

### DIFF
--- a/.changes/add-curl-ua.md
+++ b/.changes/add-curl-ua.md
@@ -1,0 +1,5 @@
+---
+"action": patch
+---
+
+Sets a User-Agent when downloading the CLI.

--- a/action.yml
+++ b/action.yml
@@ -46,19 +46,30 @@ runs:
       shell: bash
       if: steps.restore-cache.outputs.cache-hit != 'true'
       working-directory: ${{ inputs.path }}
+      env:
+        # Note: be careful about line-breaks for this parameter. Curl will break when they end up being sent as part of the header.
+        USER_AGENT: >-
+          ${{
+            format(
+              'cloud-release{0} ({1}; {2})',
+              github.action_ref && format('/{0}',github.action_ref),
+              runner.os,
+              runner.arch
+            )
+          }}
       run: |
         : Download CLI
         echo "Downloading CLI..."
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           if [[ "${{ runner.arch }}" == "X64" ]]; then
-            curl -L https://cdn.crabnebula.app/download/crabnebula/cn-cli/latest/platform/linux-binary-x86_64 --output cn
+            curl -A "$USER_AGENT" -L https://cdn.crabnebula.app/download/crabnebula/cn-cli/latest/platform/linux-binary-x86_64 --output cn
           else
-            curl -L https://cdn.crabnebula.app/download/crabnebula/cn-cli/latest/platform/linux-binary-aarch64 --output cn
+            curl -A "$USER_AGENT" -L https://cdn.crabnebula.app/download/crabnebula/cn-cli/latest/platform/linux-binary-aarch64 --output cn
           fi
         elif [[ "${{ runner.os }}" == "macOS" ]]; then
-          curl -L https://cdn.crabnebula.app/download/crabnebula/cn-cli/latest/platform/darwin-binary-universal --output cn
+          curl -A "$USER_AGENT" -L https://cdn.crabnebula.app/download/crabnebula/cn-cli/latest/platform/darwin-binary-universal --output cn
         elif [[ "${{ runner.os }}" == "Windows" ]]; then
-          curl -L https://cdn.crabnebula.app/download/crabnebula/cn-cli/latest/platform/windows-binary-x86_64 --output cn
+          curl -A "$USER_AGENT" -L https://cdn.crabnebula.app/download/crabnebula/cn-cli/latest/platform/windows-binary-x86_64 --output cn
         else
           echo "unsupported runner ${{ runner.os }}, only Linux, macOS and Windows are supported"
           exit 1


### PR DESCRIPTION
The user agent will look something like: `cloud-release/v0 (macOS; ARM64)`
Where the `v0` depends on how the caller referred to the action.

For example, when pinning to a sha hash that would be used instead.
`cloud-release/6e3b1c716307d6f1759db4b3dd976aeda0e67b7b (macOS; ARM64)`

In our test workflow, we're using a path (`./`) to refer to the action, so the `action_ref` is empty and we remove the version suffix like `cloud-release (macOS; ARM64)`.