### PR TITLE
feat(CI): extract JSON from CLI output for downstream usage

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -1,0 +1,32 @@
+# Why the GitHub Action and the CLI Are Separate
+
+While they might look like they do the same thing on the surface, they each have a distinct purpose and work together to give us a smooth CI/CD experience.
+
+## 1️⃣ The GitHub Action Is a Wrapper
+
+Think of the `cloud-release` GitHub Action as a convenience layer around the `cn` CLI. It handles all the “plumbing” that would otherwise require a bunch of manual steps in the workflow file:
+
+- **Environment detection** – automatically picks the right binary for Linux (x64/ARM), macOS, or Windows.
+- **Dependency management** – downloads the correct version of the `cn` CLI for the detected OS.
+- **Permissions** – makes sure the binary is executable (`chmod +x`).
+- **Configuration** – maps your GitHub secrets (e.g., `api-key`) straight to the CLI’s expected inputs.
+
+Without this action we’d end up writing 10‑15 lines of `curl` and conditional logic in every repo.
+
+## 2️⃣ Interoperability (Why We Need Output Variables)
+
+The `cn release draft` command prints a JSON object to stdout, but GitHub Actions can’t read that object directly. In the GitHub Actions world:
+
+- **Stdout** is just human‑readable text in the logs.
+- **Outputs** (e.g., `${{ steps.draft.outputs.release-id }}`) are special variables that later steps can consume.
+
+The action captures the CLI’s text output, extracts the hidden JSON, and explicitly tells GitHub *“this piece of text is the Release ID – store it for the next step.”* That bridge lets us use the data downstream without writing custom parsers.
+
+## 3️⃣ Separation of Concerns
+
+- **The CLI (`cn`)** – the engine. It contains the core logic for talking to CrabNebula Cloud’s API and can be used directly in a terminal or script.
+- **The Action (`cloud-release`)** – the UI/integration. It adapts the engine to the GitHub environment, exposing its functionality as native workflow variables.
+
+### TL;DR
+
+The CLI does the heavy lifting. The Action makes that work discoverable and usable as variables within a GitHub workflow, sparing us from writing custom parsing scripts in every project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## \[0.2.6]
+## [0.2.7]
+
+- Added `release`, `release-id` and `release-version` to the action outputs.
+
+## [0.2.6]
 
 - [`70f1904`](https://github.com/crabnebula-dev/cloud-release/commit/70f19045c5c3ffa7262bd5a4461ffb8cc6baa329) Sets a User-Agent when downloading the CLI.
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,15 @@ outputs:
   stdout:
     description: "The stdout of the CLI"
     value: ${{ steps.run-command.outputs.stdout }}
+  release:
+    description: "The release object as JSON"
+    value: ${{ steps.run-command.outputs.release }}
+  release-id:
+    description: "The ID of the release"
+    value: ${{ steps.run-command.outputs.release-id }}
+  release-version:
+    description: "The version of the release"
+    value: ${{ steps.run-command.outputs.release-version }}
 
 runs:
   using: 'composite'
@@ -92,8 +101,27 @@ runs:
       run: |
         : run cn ${{ inputs.command }}
         echo "running \"${{ steps.download-cn-cli.outputs.cn-path }}\" from '${{ inputs.working-directory }}'"
-        exec 5>&1
-        OUTPUT=$(${{ steps.download-cn-cli.outputs.cn-path }} ${{ inputs.command }} | tee >(cat - >&5))
+        OUTPUT=$(${{ steps.download-cn-cli.outputs.cn-path }} ${{ inputs.command }})
+        echo "$OUTPUT"
         echo "stdout<<nEOFn" >> $GITHUB_OUTPUT
         echo "$OUTPUT" >> $GITHUB_OUTPUT
         echo "nEOFn" >> $GITHUB_OUTPUT
+
+        # Try to extract JSON from the output
+        if JSON=$(echo "$OUTPUT" | sed -n '/^{/,/}/p' | jq -c '.' 2>/dev/null); then
+          if [ -n "$JSON" ]; then
+            echo "release<<nEOFn" >> $GITHUB_OUTPUT
+            echo "$JSON" >> $GITHUB_OUTPUT
+            echo "nEOFn" >> $GITHUB_OUTPUT
+
+            ID=$(echo "$JSON" | jq -r '.id // empty')
+            if [ -n "$ID" ]; then
+              echo "release-id=$ID" >> $GITHUB_OUTPUT
+            fi
+
+            VERSION=$(echo "$JSON" | jq -r '.version // empty')
+            if [ -n "$VERSION" ]; then
+              echo "release-version=$VERSION" >> $GITHUB_OUTPUT
+            fi
+          fi
+        fi

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "cloud-release",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "publish": false
 }


### PR DESCRIPTION
Exposes 
    *   `release`: The full JSON object of the release.
    *   `release-id`: The unique identifier of the created release.
    *   `release-version`: The version string of the release.
    
Added a TL;DR to help understand the how and why of this wrapper.

Bumped semver, no breaking changes.